### PR TITLE
github: Add runAttempt

### DIFF
--- a/packages/github/src/context.ts
+++ b/packages/github/src/context.ts
@@ -18,6 +18,7 @@ export class Context {
   job: string
   runNumber: number
   runId: number
+  runAttempt: number
   apiUrl: string
   serverUrl: string
   graphqlUrl: string
@@ -46,6 +47,7 @@ export class Context {
     this.job = process.env.GITHUB_JOB as string
     this.runNumber = parseInt(process.env.GITHUB_RUN_NUMBER as string, 10)
     this.runId = parseInt(process.env.GITHUB_RUN_ID as string, 10)
+    this.runAttempt = parseInt(process.env.GITHUB_RUN_ATTEMPT as string, 10)
     this.apiUrl = process.env.GITHUB_API_URL ?? `https://api.github.com`
     this.serverUrl = process.env.GITHUB_SERVER_URL ?? `https://github.com`
     this.graphqlUrl =


### PR DESCRIPTION
Adds the runAttempt variable to the context object for easier access

This wasn't included in the toolkit as of yet so I'm adding it here since I'd like to re-use this in other places as well

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>
